### PR TITLE
Harden timer loop and break overlay flow

### DIFF
--- a/Sources/NookApp/AppModel.swift
+++ b/Sources/NookApp/AppModel.swift
@@ -2,6 +2,7 @@ import AppKit
 @preconcurrency import Combine
 import Foundation
 import NookKit
+import OSLog
 import SwiftUI
 import UserNotifications
 
@@ -19,33 +20,41 @@ final class AppModel: ObservableObject {
     private let wellnessReminderEngine: WellnessReminderEngine
     private let contextualEducationEngine: ContextualEducationEngine
     private let settingsStore: SettingsStore
-    private let activityMonitor: ActivityMonitor
+    private let activityMonitor: any ActivityMonitoring
     let launchAtLoginController: LaunchAtLoginController
     private let workspaceContextProvider: any WorkspaceContextProviding
     private let fullscreenPauseProvider: FullscreenPauseConditionProvider
+    private let injectedWindowCoordinator: (any WindowCoordinator)?
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Nook", category: "Timer")
 
     private var timerCancellable: AnyCancellable?
     private var wakeObserver: NSObjectProtocol?
     private var hasHandledInitialAppLaunch = false
+    private var presentedBreakSessionID: UUID?
+    private var presentedBreakReminderDate: Date?
 
     private lazy var onboardingFlowWindowController = OnboardingFlowWindowController()
     private lazy var breakOverlayController = BreakOverlayWindowController(model: self)
     private lazy var breakReminderController = ReminderPanelController(model: self)
     private lazy var wellnessPanelController = WellnessPanelController()
-    private lazy var windowCoordinator = AppWindowCoordinator(
+    private lazy var defaultWindowCoordinator = AppWindowCoordinator(
         model: self,
         onboardingFlowController: onboardingFlowWindowController,
         breakOverlayController: breakOverlayController,
         breakReminderController: breakReminderController,
         wellnessReminderController: wellnessPanelController
     )
+    private var windowCoordinator: any WindowCoordinator {
+        injectedWindowCoordinator ?? defaultWindowCoordinator
+    }
 
     init(
         settingsStore: SettingsStore = SettingsStore(),
-        activityMonitor: ActivityMonitor = ActivityMonitor(),
+        activityMonitor: any ActivityMonitoring = ActivityMonitor(),
         scheduler: BreakScheduler? = nil,
         launchAtLoginController: LaunchAtLoginController = LaunchAtLoginController(),
         workspaceContextProvider: any WorkspaceContextProviding = WorkspaceContextProvider(),
+        windowCoordinator: (any WindowCoordinator)? = nil,
         launchConfiguration: AppLaunchConfiguration = .current,
         startsTimer: Bool = true,
         observesSystemEvents: Bool = true
@@ -74,6 +83,7 @@ final class AppModel: ObservableObject {
         self.launchAtLoginController = launchAtLoginController
         self.workspaceContextProvider = workspaceContextProvider
         self.fullscreenPauseProvider = fullscreenPauseProvider
+        self.injectedWindowCoordinator = windowCoordinator
 
         scheduler.setPauseProviders(Self.makePauseProviders(
             settings: loadedSettings,
@@ -120,9 +130,10 @@ final class AppModel: ObservableObject {
             return
         }
 
-        let snapshot = scheduler.advance(to: now, idleSeconds: activityMonitor.idleSeconds)
-        apply(snapshot: snapshot, now: now)
-        processWellnessReminders(now: now)
+        let idleSeconds = activityMonitor.idleSeconds
+        let snapshot = scheduler.advance(to: now, idleSeconds: idleSeconds)
+        apply(snapshot: snapshot, now: now, idleSeconds: idleSeconds)
+        processWellnessReminders(now: now, idleSeconds: idleSeconds)
     }
 
     func finishOnboardingFlow(workInterval: TimeInterval, breakDuration: TimeInterval) {
@@ -171,21 +182,21 @@ final class AppModel: ObservableObject {
         }
         let now = Date()
         let snapshot = scheduler.startBreakNow(at: now)
-        apply(snapshot: snapshot, now: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
     func postpone(minutes: Int) {
         guard launchPhase == .ready else { return }
         let now = Date()
         let snapshot = scheduler.postpone(minutes: minutes, now: now)
-        apply(snapshot: snapshot, now: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
     func skipCurrentBreak() {
         guard launchPhase == .ready else { return }
         let now = Date()
         let snapshot = scheduler.skipCurrentBreak(at: now)
-        apply(snapshot: snapshot, now: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
     func pauseOrResume() {
@@ -197,14 +208,14 @@ final class AppModel: ObservableObject {
         } else {
             snapshot = scheduler.pause(reason: "Paused manually", now: now)
         }
-        apply(snapshot: snapshot, now: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
     func endBreakEarly() {
         guard launchPhase == .ready else { return }
         let now = Date()
         let snapshot = scheduler.endBreakEarly(at: now)
-        apply(snapshot: snapshot, now: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
     func saveSettings() {
@@ -219,8 +230,10 @@ final class AppModel: ObservableObject {
             contextualEducationEngine.updateState(settings.contextualEducationState)
             configurePauseProviders()
             if launchPhase == .ready {
-                appState = scheduler.updateSettings(settings, now: Date()).state
-                wellnessReminderEngine.reset(at: Date())
+                let now = Date()
+                let snapshot = scheduler.updateSettings(settings, now: now)
+                apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
+                wellnessReminderEngine.reset(at: now)
             }
             applySettingsSideEffects()
             settingsError = nil
@@ -230,7 +243,7 @@ final class AppModel: ObservableObject {
     }
 
     func dismissBreakWindow() {
-        breakOverlayController.hide()
+        windowCoordinator.hideBreakOverlay()
     }
 
     func dismissStarterSetupWithDefaults() {
@@ -240,19 +253,15 @@ final class AppModel: ObservableObject {
         )
     }
 
-    private func apply(snapshot: BreakScheduler.Snapshot, now: Date) {
+    private func apply(snapshot: BreakScheduler.Snapshot, now: Date, idleSeconds: TimeInterval) {
         appState = snapshot.state
-
-        if snapshot.state.isPaused {
-            breakReminderController.hide()
-        }
+        logTimerState(snapshot: snapshot, now: now, idleSeconds: idleSeconds)
+        reconcileTimerWindows()
 
         if snapshot.reminderJustActivated, let nextBreakDate = snapshot.state.nextBreakDate {
-            _ = nextBreakDate
-            windowCoordinator.show(.breakReminder)
             scheduleNotification(
                 title: "Break almost time",
-                body: "Take a short reset in about \(Int(nextBreakDate.timeIntervalSince(now) / 60)) minute(s)."
+                body: "Take a short reset in \(nextBreakDate.timeIntervalSince(now).countdownString)."
             )
             _ = maybeShowContextualHint(.firstBreak, now: now)
         }
@@ -260,13 +269,7 @@ final class AppModel: ObservableObject {
         if snapshot.breakJustStarted, let breakSession = snapshot.state.activeBreak {
             playSound(for: settings.breakSettings.selectedSound)
             pendingWellnessEvent = nil
-            windowCoordinator.show(.breakOverlay(breakSession))
             scheduleNotification(title: breakSession.kind.title, body: breakSession.message)
-        }
-
-        if snapshot.breakJustEnded {
-            breakOverlayController.hide()
-            breakReminderController.hide()
         }
     }
 
@@ -337,12 +340,12 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func processWellnessReminders(now: Date) {
+    private func processWellnessReminders(now: Date, idleSeconds: TimeInterval) {
         let context = WellnessContext(
             isOnboardingComplete: onboardingState.hasCompletedStarterSetup,
             isPaused: appState.isPaused,
             activeBreak: appState.activeBreak,
-            idleSeconds: activityMonitor.idleSeconds,
+            idleSeconds: idleSeconds,
             isWithinOfficeHours: settings.scheduleSettings.isWithinOfficeHours(now),
             hasPendingBreakReminder: appState.reminder != nil,
             now: now
@@ -389,6 +392,59 @@ final class AppModel: ObservableObject {
         settings.contextualEducationState = contextualEducationEngine.state
         persistSettingsSnapshot()
         return true
+    }
+
+    private func reconcileTimerWindows() {
+        if let activeBreak = appState.activeBreak {
+            if !windowCoordinator.isBreakOverlayVisible || presentedBreakSessionID != activeBreak.id {
+                logger.debug("Showing break overlay session=\(activeBreak.id.uuidString, privacy: .public)")
+                windowCoordinator.showBreakOverlay(session: activeBreak)
+                presentedBreakSessionID = activeBreak.id
+            }
+
+            if windowCoordinator.isBreakReminderVisible {
+                logger.debug("Hiding break reminder because break is active")
+                windowCoordinator.hideBreakReminder()
+                presentedBreakReminderDate = nil
+            }
+            return
+        }
+
+        if windowCoordinator.isBreakOverlayVisible {
+            logger.debug("Hiding break overlay because there is no active break")
+            windowCoordinator.hideBreakOverlay()
+        }
+        presentedBreakSessionID = nil
+
+        guard !appState.isPaused,
+              appState.reminder != nil,
+              let nextBreakDate = appState.nextBreakDate
+        else {
+            if windowCoordinator.isBreakReminderVisible {
+                logger.debug("Hiding break reminder because reminder state is inactive")
+                windowCoordinator.hideBreakReminder()
+            }
+            presentedBreakReminderDate = nil
+            return
+        }
+
+        if !windowCoordinator.isBreakReminderVisible || presentedBreakReminderDate != nextBreakDate {
+            logger.debug("Showing break reminder for nextBreakDate=\(nextBreakDate.formatted(date: .omitted, time: .standard), privacy: .public)")
+            windowCoordinator.showBreakReminder(nextBreakDate: nextBreakDate)
+            presentedBreakReminderDate = nextBreakDate
+        }
+    }
+
+    private func logTimerState(snapshot: BreakScheduler.Snapshot, now: Date, idleSeconds: TimeInterval) {
+        let nextBreakDescription = snapshot.state.nextBreakDate?.formatted(date: .omitted, time: .standard) ?? "nil"
+        let activeBreakDescription = snapshot.state.activeBreak.map {
+            "\($0.kind.rawValue):\($0.scheduledEnd.formatted(date: .omitted, time: .standard))"
+        } ?? "nil"
+        let reminderVisible = self.windowCoordinator.isBreakReminderVisible
+        let overlayVisible = self.windowCoordinator.isBreakOverlayVisible
+        logger.debug(
+            "tick now=\(now.formatted(date: .omitted, time: .standard), privacy: .public) nextBreak=\(nextBreakDescription, privacy: .public) activeBreak=\(activeBreakDescription, privacy: .public) paused=\(snapshot.state.isPaused, privacy: .public) idleSeconds=\(idleSeconds, privacy: .public) reminderVisible=\(reminderVisible, privacy: .public) overlayVisible=\(overlayVisible, privacy: .public)"
+        )
     }
 
     private func persistSettingsSnapshot() {

--- a/Sources/NookApp/AppShellTypes.swift
+++ b/Sources/NookApp/AppShellTypes.swift
@@ -26,4 +26,10 @@ public protocol WindowCoordinator: AnyObject {
     func hide(_ route: WindowRoute)
     func hideAllTransientWindows()
     func isVisible(_ route: WindowRoute) -> Bool
+    func showBreakReminder(nextBreakDate: Date)
+    func hideBreakReminder()
+    var isBreakReminderVisible: Bool { get }
+    func showBreakOverlay(session: BreakSession)
+    func hideBreakOverlay()
+    var isBreakOverlayVisible: Bool { get }
 }

--- a/Sources/NookApp/AppWindowCoordinator.swift
+++ b/Sources/NookApp/AppWindowCoordinator.swift
@@ -103,6 +103,37 @@ final class AppWindowCoordinator: WindowCoordinator {
         }
     }
 
+    func showBreakReminder(nextBreakDate: Date) {
+        guard !onboardingFlowController.isVisible else { return }
+        contextualHintController.hide()
+        wellnessReminderController.hide()
+        breakReminderController.show(nextBreakDate: nextBreakDate)
+    }
+
+    func hideBreakReminder() {
+        breakReminderController.hide()
+    }
+
+    var isBreakReminderVisible: Bool {
+        breakReminderController.isVisible
+    }
+
+    func showBreakOverlay(session: BreakSession) {
+        guard !onboardingFlowController.isVisible else { return }
+        breakReminderController.hide()
+        wellnessReminderController.hide()
+        contextualHintController.hide()
+        breakOverlayController.show(session: session)
+    }
+
+    func hideBreakOverlay() {
+        breakOverlayController.hide()
+    }
+
+    var isBreakOverlayVisible: Bool {
+        breakOverlayController.isVisible
+    }
+
     private func showOnboardingFlow() {
         hideAllTransientWindows()
         onboardingFlowController.show { [weak self] workInterval, breakDuration in

--- a/Sources/NookApp/BreakOverlayView.swift
+++ b/Sources/NookApp/BreakOverlayView.swift
@@ -6,9 +6,8 @@ struct BreakOverlayView: View {
     let session: BreakSession
     @State private var contentVisible = false
 
-    private var remainingSeconds: Int {
-        guard let activeBreak = model.appState.activeBreak else { return 0 }
-        return Int(max(activeBreak.scheduledEnd.timeIntervalSince(model.appState.now), 0))
+    private var remainingText: String {
+        model.appState.countdownText ?? "00:00"
     }
 
     var body: some View {
@@ -27,7 +26,7 @@ struct BreakOverlayView: View {
                     .foregroundStyle(.white)
                     .frame(maxWidth: 600)
 
-                Text("Break ends in \(remainingSeconds)s")
+                Text("Break ends in \(remainingText)")
                     .font(.system(size: 17, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(.white.opacity(0.6))

--- a/Sources/NookApp/BreakOverlayWindowController.swift
+++ b/Sources/NookApp/BreakOverlayWindowController.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @MainActor
 final class BreakOverlayWindowController {
-    private weak var window: NSWindow?
+    private var window: NSWindow?
     private let model: AppModel
 
     init(model: AppModel) {
@@ -53,6 +53,10 @@ final class BreakOverlayWindowController {
                 window.orderOut(nil)
             }
         })
+    }
+
+    var isVisible: Bool {
+        window?.isVisible == true
     }
 
     private func makeWindow() -> NSWindow {

--- a/Sources/NookApp/NookApp.swift
+++ b/Sources/NookApp/NookApp.swift
@@ -28,36 +28,12 @@ struct NookApp: App {
 
     @ViewBuilder
     private var menuBarLabel: some View {
-        if let countdownText = urgentCountdownText {
+        if let countdownText = model.appState.countdownText, model.launchPhase == .ready {
             Text(countdownText)
                 .monospacedDigit()
         } else {
             MenuBarIcon()
         }
-    }
-
-    private var urgentCountdownText: String? {
-        guard model.launchPhase == .ready else { return nil }
-
-        if let activeBreak = model.appState.activeBreak {
-            let remaining = max(activeBreak.scheduledEnd.timeIntervalSince(model.appState.now), 0)
-            if remaining <= 60 {
-                return "\(Int(remaining))s"
-            }
-            return nil
-        }
-
-        if let nextBreakDate = model.appState.nextBreakDate {
-            let remaining = max(nextBreakDate.timeIntervalSince(model.appState.now), 0)
-            if remaining <= 10 {
-                return "Break in \(Int(remaining))s"
-            } else if remaining <= 60 {
-                return "\(Int(remaining))s"
-            }
-            return nil
-        }
-
-        return nil
     }
 }
 

--- a/Sources/NookApp/OnboardingFlowWindowController.swift
+++ b/Sources/NookApp/OnboardingFlowWindowController.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @MainActor
 final class OnboardingFlowWindowController {
-    private weak var window: NSWindow?
+    private var window: NSWindow?
 
     func show(onFinish: @escaping @MainActor (TimeInterval, TimeInterval) -> Void) {
         let window = window ?? makeWindow()

--- a/Sources/NookApp/ReminderPanelController.swift
+++ b/Sources/NookApp/ReminderPanelController.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @MainActor
 final class ReminderPanelController {
-    private weak var panel: NSPanel?
+    private var panel: NSPanel?
     private weak var model: AppModel?
 
     init(model: AppModel) {
@@ -19,6 +19,10 @@ final class ReminderPanelController {
 
     func hide() {
         panel?.orderOut(nil)
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible == true
     }
 
     private func makePanel() -> NSPanel {

--- a/Sources/NookApp/StatusMenuView.swift
+++ b/Sources/NookApp/StatusMenuView.swift
@@ -52,14 +52,14 @@ struct StatusMenuView: View {
                 LabeledContent("Next break", value: nextBreakDate.formatted(date: .omitted, time: .shortened))
                 LabeledContent(
                     "Countdown",
-                    value: max(nextBreakDate.timeIntervalSince(model.appState.now), 0).clockString
+                    value: max(nextBreakDate.timeIntervalSince(model.appState.now), 0).countdownString
                 )
             }
 
-            if let activeBreak = model.appState.activeBreak {
+            if model.appState.activeBreak != nil, let countdownText = model.appState.countdownText {
                 LabeledContent(
                     "Remaining",
-                    value: "\(Int(max(activeBreak.scheduledEnd.timeIntervalSince(model.appState.now), 0)))s"
+                    value: countdownText
                 )
             }
 

--- a/Sources/NookApp/TimerPhaseDisplay.swift
+++ b/Sources/NookApp/TimerPhaseDisplay.swift
@@ -1,0 +1,35 @@
+import Foundation
+import NookKit
+
+enum TimerPhase: Equatable {
+    case work
+    case breakTime
+    case idle
+}
+
+extension AppState {
+    var timerPhase: TimerPhase {
+        if activeBreak != nil {
+            return .breakTime
+        }
+
+        if nextBreakDate != nil {
+            return .work
+        }
+
+        return .idle
+    }
+
+    var countdownTargetDate: Date? {
+        activeBreak?.scheduledEnd ?? nextBreakDate
+    }
+
+    var remainingCountdown: TimeInterval? {
+        guard let countdownTargetDate else { return nil }
+        return max(countdownTargetDate.timeIntervalSince(now), 0)
+    }
+
+    var countdownText: String? {
+        remainingCountdown?.countdownString
+    }
+}

--- a/Sources/NookApp/WellnessPanelController.swift
+++ b/Sources/NookApp/WellnessPanelController.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @MainActor
 final class WellnessPanelController {
-    private weak var panel: NSPanel?
+    private var panel: NSPanel?
     private var dismissTask: Task<Void, Never>?
 
     func show(event: WellnessReminderEvent) {

--- a/Sources/NookKit/ActivityMonitor.swift
+++ b/Sources/NookKit/ActivityMonitor.swift
@@ -1,7 +1,11 @@
 import AppKit
 import Foundation
 
-public final class ActivityMonitor {
+public protocol ActivityMonitoring: Sendable {
+    var idleSeconds: TimeInterval { get }
+}
+
+public final class ActivityMonitor: ActivityMonitoring, @unchecked Sendable {
     public init() {}
 
     public var idleSeconds: TimeInterval {

--- a/Sources/NookKit/BreakScheduler.swift
+++ b/Sources/NookKit/BreakScheduler.swift
@@ -120,7 +120,7 @@ public final class BreakScheduler: @unchecked Sendable {
             }
 
             let remaining = breakSession.scheduledEnd.timeIntervalSince(now)
-            statusText = "\(breakSession.kind.title) in progress (\(remaining.clockString) left)"
+            statusText = "\(breakSession.kind.title) in progress (\(remaining.countdownString) left)"
             return snapshot(now: now, reminderJustActivated: false, breakJustStarted: false, breakJustEnded: false)
         }
 
@@ -144,7 +144,7 @@ public final class BreakScheduler: @unchecked Sendable {
             now < nextBreakDate
         if shouldShowReminder {
             reminderForBreakDate = nextBreakDate
-            statusText = "Break coming up in \(nextBreakDate.timeIntervalSince(now).clockString)"
+            statusText = "Break coming up in \(nextBreakDate.timeIntervalSince(now).countdownString)"
             return snapshot(
                 now: now,
                 reminderJustActivated: !reminderWasVisible,
@@ -160,7 +160,7 @@ public final class BreakScheduler: @unchecked Sendable {
             return snapshot(now: now, reminderJustActivated: false, breakJustStarted: true, breakJustEnded: false)
         }
 
-        statusText = "Next break in \(nextBreakDate.timeIntervalSince(now).clockString)"
+        statusText = "Next break in \(nextBreakDate.timeIntervalSince(now).countdownString)"
         return snapshot(now: now, reminderJustActivated: false, breakJustStarted: false, breakJustEnded: false)
     }
 
@@ -302,7 +302,7 @@ public final class BreakScheduler: @unchecked Sendable {
         suppressReminderForCurrentBreak = false
         postponedUntil = nil
         nextBreakDate = now.addingTimeInterval(settings.breakSettings.workInterval)
-        statusText = "Nice work. Next break in \(settings.breakSettings.workInterval.clockString)"
+        statusText = "Nice work. Next break in \(settings.breakSettings.workInterval.countdownString)"
     }
 
     private var nextBreakKind: BreakKind {

--- a/Sources/NookKit/Models.swift
+++ b/Sources/NookKit/Models.swift
@@ -552,10 +552,14 @@ public struct AppState: Sendable {
 }
 
 public extension TimeInterval {
-    var clockString: String {
-        let total = max(Int(self.rounded()), 0)
+    var countdownString: String {
+        let total = max(Int(ceil(self)), 0)
         let minutes = total / 60
         let seconds = total % 60
         return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var clockString: String {
+        countdownString
     }
 }

--- a/Tests/NookAppTests/AppModelTimerTests.swift
+++ b/Tests/NookAppTests/AppModelTimerTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import NookKit
+@testable import NookApp
+import XCTest
+
+@MainActor
+final class AppModelTimerTests: XCTestCase {
+    private struct MockActivityMonitor: ActivityMonitoring {
+        var idleSeconds: TimeInterval
+    }
+
+    private final class MockWindowCoordinator: WindowCoordinator {
+        var onboardingVisible = false
+        var showBreakReminderCalls = 0
+        var hideBreakReminderCalls = 0
+        var showBreakOverlayCalls = 0
+        var hideBreakOverlayCalls = 0
+        var isBreakReminderVisible = false
+        var isBreakOverlayVisible = false
+        var shownBreakReminderDates: [Date] = []
+        var shownBreakOverlaySessions: [BreakSession] = []
+
+        func show(_ route: WindowRoute) {
+            switch route {
+            case .onboardingFlow:
+                onboardingVisible = true
+            case .breakReminder:
+                isBreakReminderVisible = true
+            case .breakOverlay:
+                isBreakOverlayVisible = true
+            default:
+                break
+            }
+        }
+
+        func hide(_ route: WindowRoute) {
+            switch route {
+            case .onboardingFlow:
+                onboardingVisible = false
+            case .breakReminder:
+                isBreakReminderVisible = false
+            case .breakOverlay:
+                isBreakOverlayVisible = false
+            default:
+                break
+            }
+        }
+
+        func hideAllTransientWindows() {
+            isBreakReminderVisible = false
+            isBreakOverlayVisible = false
+        }
+
+        func isVisible(_ route: WindowRoute) -> Bool {
+            switch route {
+            case .onboardingFlow:
+                onboardingVisible
+            case .breakReminder:
+                isBreakReminderVisible
+            case .breakOverlay:
+                isBreakOverlayVisible
+            default:
+                false
+            }
+        }
+
+        func showBreakReminder(nextBreakDate: Date) {
+            showBreakReminderCalls += 1
+            isBreakReminderVisible = true
+            shownBreakReminderDates.append(nextBreakDate)
+        }
+
+        func hideBreakReminder() {
+            hideBreakReminderCalls += 1
+            isBreakReminderVisible = false
+        }
+
+        func showBreakOverlay(session: BreakSession) {
+            showBreakOverlayCalls += 1
+            isBreakOverlayVisible = true
+            shownBreakOverlaySessions.append(session)
+        }
+
+        func hideBreakOverlay() {
+            hideBreakOverlayCalls += 1
+            isBreakOverlayVisible = false
+        }
+    }
+
+    func testWorkPhaseCountdownDecreasesEveryTick() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 120,
+            breakDuration: 20,
+            reminderLeadTime: 0,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        XCTAssertEqual(model.appState.timerPhase, .work)
+        XCTAssertEqual(model.appState.countdownText, "02:00")
+
+        model.tick(now: start.addingTimeInterval(1))
+        XCTAssertEqual(model.appState.countdownText, "01:59")
+    }
+
+    func testBreakPhaseCountdownDecreasesEveryTick() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 60,
+            breakDuration: 20,
+            reminderLeadTime: 0,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        model.tick(now: start.addingTimeInterval(60))
+
+        XCTAssertEqual(model.appState.timerPhase, .breakTime)
+        XCTAssertEqual(model.appState.countdownText, "00:20")
+
+        model.tick(now: start.addingTimeInterval(61))
+        XCTAssertEqual(model.appState.countdownText, "00:19")
+    }
+
+    func testWorkCompletionShowsBreakOverlayFromState() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 60,
+            breakDuration: 20,
+            reminderLeadTime: 0,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        model.tick(now: start.addingTimeInterval(60))
+
+        XCTAssertNotNil(model.appState.activeBreak)
+        XCTAssertEqual(coordinator.showBreakOverlayCalls, 1)
+        XCTAssertTrue(coordinator.isBreakOverlayVisible)
+    }
+
+    func testHiddenBreakOverlayIsShownAgainOnNextTick() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 60,
+            breakDuration: 20,
+            reminderLeadTime: 0,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        model.tick(now: start.addingTimeInterval(60))
+        coordinator.isBreakOverlayVisible = false
+
+        model.tick(now: start.addingTimeInterval(61))
+
+        XCTAssertEqual(coordinator.showBreakOverlayCalls, 2)
+        XCTAssertTrue(coordinator.isBreakOverlayVisible)
+    }
+
+    func testHiddenReminderPanelIsShownAgainWhileReminderStateIsActive() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 120,
+            breakDuration: 20,
+            reminderLeadTime: 60,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        model.tick(now: start.addingTimeInterval(60))
+        coordinator.isBreakReminderVisible = false
+
+        model.tick(now: start.addingTimeInterval(61))
+
+        XCTAssertEqual(coordinator.showBreakReminderCalls, 2)
+        XCTAssertTrue(coordinator.isBreakReminderVisible)
+    }
+
+    func testDelayedTickStartsBreakUsingAbsoluteTime() throws {
+        let coordinator = MockWindowCoordinator()
+        let model = try makeModel(
+            workInterval: 60,
+            breakDuration: 20,
+            reminderLeadTime: 0,
+            windowCoordinator: coordinator
+        )
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        model.handleAppDidFinishLaunching(now: start)
+        model.tick(now: start.addingTimeInterval(300))
+
+        XCTAssertEqual(model.appState.timerPhase, .breakTime)
+        XCTAssertNotNil(model.appState.activeBreak)
+        XCTAssertEqual(coordinator.showBreakOverlayCalls, 1)
+    }
+
+    private func makeModel(
+        workInterval: TimeInterval,
+        breakDuration: TimeInterval,
+        reminderLeadTime: TimeInterval,
+        windowCoordinator: MockWindowCoordinator
+    ) throws -> AppModel {
+        var settings = completedSettings()
+        settings.breakSettings.workInterval = workInterval
+        settings.breakSettings.microBreakDuration = breakDuration
+        settings.breakSettings.reminderLeadTime = reminderLeadTime
+        settings.smartPauseSettings.pauseDuringFullscreenFocus = false
+        let store = try makeStore(with: settings)
+
+        return AppModel(
+            settingsStore: store,
+            activityMonitor: MockActivityMonitor(idleSeconds: 0),
+            windowCoordinator: windowCoordinator,
+            launchConfiguration: AppLaunchConfiguration(forceOnboarding: false),
+            startsTimer: false,
+            observesSystemEvents: false
+        )
+    }
+
+    private func completedSettings() -> AppSettings {
+        var settings = AppSettings.default
+        settings.onboardingState = OnboardingState(
+            hasCompletedStarterSetup: true,
+            completedAt: Date(timeIntervalSinceReferenceDate: 1234),
+            lastCompletedVersion: AppSettings.currentSchemaVersion
+        )
+        return settings
+    }
+
+    private func makeStore(with settings: AppSettings) throws -> SettingsStore {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let store = SettingsStore(fileURL: directory.appendingPathComponent("settings.json"))
+        try store.save(settings)
+        return store
+    }
+}

--- a/Tests/NookKitTests/TimeIntervalFormattingTests.swift
+++ b/Tests/NookKitTests/TimeIntervalFormattingTests.swift
@@ -1,0 +1,11 @@
+import NookKit
+import XCTest
+
+final class TimeIntervalFormattingTests: XCTestCase {
+    func testCountdownStringUsesSharedMmSsFormatting() {
+        XCTAssertEqual(TimeInterval(60).countdownString, "01:00")
+        XCTAssertEqual(TimeInterval(59.6).countdownString, "01:00")
+        XCTAssertEqual(TimeInterval(0.4).countdownString, "00:01")
+        XCTAssertEqual(TimeInterval(0).countdownString, "00:00")
+    }
+}


### PR DESCRIPTION
## TL;DR
This makes the menu bar countdown always reflect the current phase, reconciles break/reminder UI from `AppState` on every tick, and hardens the break overlay so work-to-break transitions remain visible even if a one-shot event is missed.

## Overview
The scheduler math was already correct, but the app integration layer had a few weak spots:
- the menu bar only showed an urgent countdown instead of the active phase countdown
- the break overlay depended on a one-shot transition event
- transient timer windows were weakly held
- countdown formatting differed across surfaces

This change makes the timer loop state-driven at the UI layer while keeping edge-triggered events only for one-time side effects like sound and notifications.

## Summary
- add shared countdown helpers for `AppState` and `TimeInterval`
- always render the current phase countdown in the menu bar, status menu, and break overlay
- reconcile break overlay and reminder visibility from `AppState` each tick
- keep timer-related windows strongly referenced while visible
- inject `ActivityMonitoring` and `WindowCoordinator` for deterministic timer integration tests
- add timer regression coverage for countdown updates, delayed ticks, and hidden-window recovery
- add lightweight timer instrumentation with `OSLog`

## Testing
- `swift test`

Closes #1