### PR TITLE
Add local development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ swift build
 Run the app:
 
 ```bash
-swift run Nook
+swift run
 ```
 
-Force starter setup during local development:
+For the full local development workflow, including `swift run Nook`, filtered test commands, and launch-time overrides such as `NOOK_WORK`, `NOOK_BREAK`, and `NOOK_FORCE_ONBOARDING`, see [docs/local-development.md](docs/local-development.md).
 
-```bash
-NOOK_FORCE_ONBOARDING=1 swift run Nook
-```
-
-Run tests:
+Quick examples:
 
 ```bash
 swift test
+```
+
+```bash
+NOOK_FORCE_ONBOARDING=1 swift run
 ```
 
 `swift test` currently expects a full Xcode installation in this repository's setup.
@@ -101,7 +101,7 @@ swift test
 - `Sources/NookApp/`: macOS app shell, menu bar UI, windows, and app coordination
 - `Sources/NookKit/`: scheduler, models, persistence, and platform integration
 - `Tests/`: scheduler, persistence, and app test coverage
-- `docs/`: release and supporting project docs
+- `docs/`: release and supporting project docs, including the local development guide
 - `packaging/`: macOS packaging assets and helper scripts
 
 ## Contributing

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,78 @@
+# Local Development
+
+This guide covers the fastest way to build, run, and test Nook locally.
+
+## Requirements
+
+- macOS 13 or newer
+- a current Swift toolchain
+- a full Xcode installation for the best local development experience
+
+## Build
+
+Build the package from the repository root:
+
+```bash
+swift build
+```
+
+## Run
+
+Launch the app from the repository root:
+
+```bash
+swift run
+```
+
+`swift run Nook` is also valid in this package because Nook is the executable product.
+
+## Test
+
+Run the full test suite:
+
+```bash
+swift test
+```
+
+Run a targeted test class while iterating:
+
+```bash
+swift test --filter AppModelLaunchTests
+```
+
+`swift test` currently expects a full Xcode installation in this repository's setup.
+
+## Fast Local Iteration
+
+Nook supports launch-time environment variable overrides for local testing. These values are read when the app starts, override whatever is currently saved in settings, and do not persist back to disk.
+
+Available overrides:
+
+- `NOOK_WORK=<seconds>` sets the work interval for the current launch only
+- `NOOK_BREAK=<seconds>` sets the break duration for the current launch only
+- `NOOK_FORCE_ONBOARDING=1` forces the onboarding flow for the current launch only
+
+Examples:
+
+```bash
+# 10s work, 5s break
+NOOK_WORK=10 NOOK_BREAK=5 swift run
+
+# 30s work, default break
+NOOK_WORK=30 swift run
+
+# Combine with force onboarding
+NOOK_FORCE_ONBOARDING=1 NOOK_WORK=10 NOOK_BREAK=5 swift run
+```
+
+Values are in seconds. They override whatever is saved in settings without persisting.
+
+## What To Verify
+
+When using the short-duration overrides above, you should see:
+
+- a reminder or break cycle arrive much sooner than your normal saved schedule
+- a shorter break end more quickly when `NOOK_BREAK` is set
+- the onboarding flow appear when `NOOK_FORCE_ONBOARDING=1` is set
+
+Forced onboarding is only a launch-time override. It does not overwrite the saved onboarding state until you explicitly complete or dismiss the setup flow.


### PR DESCRIPTION
## Summary
- add a dedicated local development guide under docs/
- document build, run, and test workflows for contributors
- document the NOOK_WORK, NOOK_BREAK, and NOOK_FORCE_ONBOARDING launch-time overrides

## Testing
- swift test --filter AppModelLaunchTests