### PR TITLE
Polish menu bar countdown behavior

### DIFF
--- a/Sources/NookApp/AppLaunchConfiguration.swift
+++ b/Sources/NookApp/AppLaunchConfiguration.swift
@@ -2,13 +2,21 @@ import Foundation
 
 struct AppLaunchConfiguration: Sendable, Equatable {
     let forceOnboarding: Bool
+    /// Override work interval in seconds (e.g. NOOK_WORK=10 for 10s)
+    let workIntervalOverride: TimeInterval?
+    /// Override break duration in seconds (e.g. NOOK_BREAK=5 for 5s)
+    let breakDurationOverride: TimeInterval?
 
-    init(forceOnboarding: Bool = false) {
+    init(forceOnboarding: Bool = false, workIntervalOverride: TimeInterval? = nil, breakDurationOverride: TimeInterval? = nil) {
         self.forceOnboarding = forceOnboarding
+        self.workIntervalOverride = workIntervalOverride
+        self.breakDurationOverride = breakDurationOverride
     }
 
     init(environment: [String: String]) {
         self.forceOnboarding = Self.parseBoolean(environment["NOOK_FORCE_ONBOARDING"])
+        self.workIntervalOverride = Self.parseSeconds(environment["NOOK_WORK"])
+        self.breakDurationOverride = Self.parseSeconds(environment["NOOK_BREAK"])
     }
 
     static let current = AppLaunchConfiguration(environment: ProcessInfo.processInfo.environment)
@@ -24,5 +32,13 @@ struct AppLaunchConfiguration: Sendable, Equatable {
         default:
             return false
         }
+    }
+
+    private static func parseSeconds(_ rawValue: String?) -> TimeInterval? {
+        guard let raw = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let value = TimeInterval(raw), value > 0 else {
+            return nil
+        }
+        return value
     }
 }

--- a/Sources/NookApp/AppModel.swift
+++ b/Sources/NookApp/AppModel.swift
@@ -61,7 +61,13 @@ final class AppModel: ObservableObject {
     ) {
         self.settingsStore = settingsStore
         self.activityMonitor = activityMonitor
-        let loadedSettings = (try? settingsStore.load()) ?? .default
+        var loadedSettings = (try? settingsStore.load()) ?? .default
+        if let work = launchConfiguration.workIntervalOverride {
+            loadedSettings.breakSettings.workInterval = work
+        }
+        if let brk = launchConfiguration.breakDurationOverride {
+            loadedSettings.breakSettings.microBreakDuration = brk
+        }
         let requiresStarterSetup = Self.requiresStarterSetup(
             settings: loadedSettings,
             launchConfiguration: launchConfiguration

--- a/Sources/NookApp/MenuBarLabelView.swift
+++ b/Sources/NookApp/MenuBarLabelView.swift
@@ -1,0 +1,72 @@
+import NookKit
+import SwiftUI
+
+struct MenuBarLabelContent: Equatable {
+    var symbolName: String
+    var countdownText: String?
+    var accessibilityLabel: String
+}
+
+enum MenuBarLabelFormatter {
+    static func content(launchPhase: AppLaunchPhase, state: AppState) -> MenuBarLabelContent {
+        guard launchPhase == .ready else {
+            return MenuBarLabelContent(
+                symbolName: "pause.fill",
+                countdownText: nil,
+                accessibilityLabel: "Nook"
+            )
+        }
+
+        if let activeBreak = state.activeBreak {
+            return MenuBarLabelContent(
+                symbolName: "pause.circle.fill",
+                countdownText: state.countdownText,
+                accessibilityLabel: "\(activeBreak.kind.title) in progress"
+            )
+        }
+
+        if state.isPaused {
+            return MenuBarLabelContent(
+                symbolName: "pause.slash.fill",
+                countdownText: nil,
+                accessibilityLabel: state.pauseReason ?? "Paused"
+            )
+        }
+
+        if state.nextBreakDate != nil {
+            return MenuBarLabelContent(
+                symbolName: state.reminder == nil ? "hourglass" : "bell.badge.fill",
+                countdownText: state.countdownText,
+                accessibilityLabel: "Next break countdown"
+            )
+        }
+
+        return MenuBarLabelContent(
+            symbolName: "pause.fill",
+            countdownText: nil,
+            accessibilityLabel: state.statusText
+        )
+    }
+}
+
+struct MenuBarLabelView: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        let content = MenuBarLabelFormatter.content(
+            launchPhase: model.launchPhase,
+            state: model.appState
+        )
+
+        HStack(spacing: 6) {
+            Image(systemName: content.symbolName)
+
+            if let countdownText = content.countdownText {
+                Text(countdownText)
+                    .monospacedDigit()
+            }
+        }
+        .help(model.appState.statusText)
+        .accessibilityLabel(content.accessibilityLabel)
+    }
+}

--- a/Sources/NookApp/NookApp.swift
+++ b/Sources/NookApp/NookApp.swift
@@ -18,27 +18,11 @@ struct NookApp: App {
         MenuBarExtra {
             StatusMenuView(model: model)
         } label: {
-            menuBarLabel
+            MenuBarLabelView(model: model)
         }
 
         Settings {
             SettingsView(model: model)
         }
-    }
-
-    @ViewBuilder
-    private var menuBarLabel: some View {
-        if let countdownText = model.appState.countdownText, model.launchPhase == .ready {
-            Text(countdownText)
-                .monospacedDigit()
-        } else {
-            MenuBarIcon()
-        }
-    }
-}
-
-private struct MenuBarIcon: View {
-    var body: some View {
-        Image(systemName: "pause.fill")
     }
 }

--- a/Sources/NookKit/BreakScheduler.swift
+++ b/Sources/NookKit/BreakScheduler.swift
@@ -40,6 +40,7 @@ public final class BreakScheduler: @unchecked Sendable {
     private var completedMicroBreaks = 0
     private var postponedUntil: Date?
     private var lastKnownNow: Date?
+    private var idleResetApplied = false
     private var statusText = "Preparing your first session"
     private let smartPauseResumeGracePeriod: TimeInterval = 2 * 60
 
@@ -106,11 +107,16 @@ public final class BreakScheduler: @unchecked Sendable {
         }
 
         if activeBreak == nil, idleSeconds >= settings.scheduleSettings.idleResetThreshold {
-            nextBreakDate = now.addingTimeInterval(settings.breakSettings.workInterval)
-            reminderForBreakDate = nil
-            postponedUntil = nil
-            suppressReminderForCurrentBreak = false
+            if !idleResetApplied {
+                nextBreakDate = now.addingTimeInterval(settings.breakSettings.workInterval)
+                reminderForBreakDate = nil
+                postponedUntil = nil
+                suppressReminderForCurrentBreak = false
+                idleResetApplied = true
+            }
             statusText = "Timer reset after idle time"
+        } else {
+            idleResetApplied = false
         }
 
         if let breakSession = activeBreak {

--- a/Tests/NookAppTests/MenuBarLabelFormatterTests.swift
+++ b/Tests/NookAppTests/MenuBarLabelFormatterTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import NookKit
+@testable import NookApp
+import XCTest
+
+final class MenuBarLabelFormatterTests: XCTestCase {
+    func testUsesBreakCountdownDuringActiveBreak() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let activeBreak = BreakSession(
+            kind: .micro,
+            startedAt: now,
+            scheduledEnd: now.addingTimeInterval(20),
+            message: "Rest your eyes",
+            backgroundStyle: .dawn,
+            skipAvailableAfter: now
+        )
+        let state = AppState(
+            now: now,
+            nextBreakDate: nil,
+            activeBreak: activeBreak,
+            reminder: nil,
+            isPaused: false,
+            pauseReason: nil,
+            statusText: "Short Break in progress (00:20 left)"
+        )
+
+        let content = MenuBarLabelFormatter.content(launchPhase: .ready, state: state)
+
+        XCTAssertEqual(content.symbolName, "pause.circle.fill")
+        XCTAssertEqual(content.countdownText, "00:20")
+    }
+
+    func testUsesNextBreakCountdownWhenScheduleIsActive() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let state = AppState(
+            now: now,
+            nextBreakDate: now.addingTimeInterval(5 * 60),
+            activeBreak: nil,
+            reminder: nil,
+            isPaused: false,
+            pauseReason: nil,
+            statusText: "Next break in 05:00"
+        )
+
+        let content = MenuBarLabelFormatter.content(launchPhase: .ready, state: state)
+
+        XCTAssertEqual(content.symbolName, "hourglass")
+        XCTAssertEqual(content.countdownText, "05:00")
+    }
+
+    func testUsesReminderSymbolWhileReminderIsVisible() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let state = AppState(
+            now: now,
+            nextBreakDate: now.addingTimeInterval(45),
+            activeBreak: nil,
+            reminder: ReminderState(
+                dueDate: now,
+                scheduledBreakDate: now.addingTimeInterval(45)
+            ),
+            isPaused: false,
+            pauseReason: nil,
+            statusText: "Break coming up in 00:45"
+        )
+
+        let content = MenuBarLabelFormatter.content(launchPhase: .ready, state: state)
+
+        XCTAssertEqual(content.symbolName, "bell.badge.fill")
+        XCTAssertEqual(content.countdownText, "00:45")
+    }
+
+    func testUsesPausedIconWithoutFrozenTimer() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let state = AppState(
+            now: now,
+            nextBreakDate: now.addingTimeInterval(5 * 60),
+            activeBreak: nil,
+            reminder: nil,
+            isPaused: true,
+            pauseReason: "Full-Screen Focus",
+            statusText: "Paused by Full-Screen Focus"
+        )
+
+        let content = MenuBarLabelFormatter.content(launchPhase: .ready, state: state)
+
+        XCTAssertEqual(content.symbolName, "pause.slash.fill")
+        XCTAssertNil(content.countdownText)
+    }
+}


### PR DESCRIPTION
## TL;DR
- Adds a real menu bar countdown for active breaks and upcoming breaks instead of only showing the icon or a last-second timer.
- Reuses the same `clockString` formatting in the break overlay and status menu so the timer UI stays consistent.
- Adds `NOOK_WORK` and `NOOK_BREAK` launch overrides for faster local iteration, while hardening idle reset behavior.

## Summary
- Extracts menu bar label rendering into `MenuBarLabelFormatter` and `MenuBarLabelView`.
- Shows countdown text during active breaks, reminder windows, and normal next-break scheduling with state-specific symbols.
- Removes the extra pre-break reminder popup/notification path from `AppModel` so the menu bar countdown is the primary signal before a break starts.
- Uses shared `clockString` formatting for break remaining time in the overlay and status menu.
- Supports launch-time work and break duration overrides via environment variables.
- Prevents idle resets from repeatedly extending the timer while the user remains idle.
- Adds focused tests for the new menu bar label behavior.

## Overview
This PR makes the timer feel visible all the time from the menu bar instead of only surfacing urgency in the last few seconds. It also smooths a couple of adjacent timer workflows for local development and idle recovery, while keeping hardcore skip rules intact.

## Testing
- `swift test`
