### PR TITLE
Fix dark mode support for menu bar icon and popover

### DIFF
--- a/Sources/AppShell/ApplicationDelegate.swift
+++ b/Sources/AppShell/ApplicationDelegate.swift
@@ -12,6 +12,7 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
     private var cancellables = Set<AnyCancellable>()
     private var eventMonitor: Any?
     private var lastCloseDate: Date = .distantPast
+    private var lastMenuBarContent: MenuBarLabelContent?
 
     override init() {
         let resolvedUpdateManager = GitHubReleaseUpdateManager()
@@ -125,18 +126,35 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
     private func updateStatusBarButton(content: MenuBarLabelContent) {
         guard let button = statusItem.button else { return }
-        let symbolImage = NSImage(
-            systemSymbolName: content.symbolName,
-            accessibilityDescription: content.accessibilityLabel
-        )
-        button.image = content.showsUpdateBadge ? badgedMenuBarImage(from: symbolImage) : symbolImage
-        if let countdown = content.countdownText {
+        defer { lastMenuBarContent = content }
+
+        let imageChanged = lastMenuBarContent?.symbolName != content.symbolName
+            || lastMenuBarContent?.showsUpdateBadge != content.showsUpdateBadge
+
+        if imageChanged {
+            let symbolImage = NSImage(
+                systemSymbolName: content.symbolName,
+                accessibilityDescription: content.accessibilityLabel
+            )
+            symbolImage?.isTemplate = true
+            button.image = content.showsUpdateBadge ? badgedMenuBarImage(from: symbolImage) : symbolImage
+        }
+
+        let hadCountdown = lastMenuBarContent?.countdownText != nil
+        let hasCountdown = content.countdownText != nil
+
+        if hadCountdown != hasCountdown {
+            if hasCountdown {
+                button.imagePosition = .imageLeading
+                button.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
+            } else {
+                button.title = ""
+                button.imagePosition = .imageOnly
+            }
+        }
+
+        if let countdown = content.countdownText, countdown != lastMenuBarContent?.countdownText {
             button.title = countdown
-            button.imagePosition = .imageLeading
-            button.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
-        } else {
-            button.title = ""
-            button.imagePosition = .imageOnly
         }
     }
 
@@ -159,6 +177,7 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
         NSColor.systemRed.setFill()
         NSBezierPath(ovalIn: badgeRect).fill()
 
+        image.isTemplate = true
         return image
     }
 

--- a/Sources/AppShell/ApplicationDelegate.swift
+++ b/Sources/AppShell/ApplicationDelegate.swift
@@ -126,35 +126,22 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
     private func updateStatusBarButton(content: MenuBarLabelContent) {
         guard let button = statusItem.button else { return }
+        guard content != lastMenuBarContent else { return }
         defer { lastMenuBarContent = content }
 
-        let imageChanged = lastMenuBarContent?.symbolName != content.symbolName
-            || lastMenuBarContent?.showsUpdateBadge != content.showsUpdateBadge
-
-        if imageChanged {
-            let symbolImage = NSImage(
-                systemSymbolName: content.symbolName,
-                accessibilityDescription: content.accessibilityLabel
-            )
-            symbolImage?.isTemplate = true
-            button.image = content.showsUpdateBadge ? badgedMenuBarImage(from: symbolImage) : symbolImage
-        }
-
-        let hadCountdown = lastMenuBarContent?.countdownText != nil
-        let hasCountdown = content.countdownText != nil
-
-        if hadCountdown != hasCountdown {
-            if hasCountdown {
-                button.imagePosition = .imageLeading
-                button.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
-            } else {
-                button.title = ""
-                button.imagePosition = .imageOnly
-            }
-        }
-
-        if let countdown = content.countdownText, countdown != lastMenuBarContent?.countdownText {
+        let symbolImage = NSImage(
+            systemSymbolName: content.symbolName,
+            accessibilityDescription: content.accessibilityLabel
+        )
+        symbolImage?.isTemplate = true
+        button.image = content.showsUpdateBadge ? badgedMenuBarImage(from: symbolImage) : symbolImage
+        if let countdown = content.countdownText {
             button.title = countdown
+            button.imagePosition = .imageLeading
+            button.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
+        } else {
+            button.title = ""
+            button.imagePosition = .imageOnly
         }
     }
 
@@ -177,7 +164,6 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
         NSColor.systemRed.setFill()
         NSBezierPath(ovalIn: badgeRect).fill()
 
-        image.isTemplate = true
         return image
     }
 

--- a/Sources/AppShell/StatusMenuView.swift
+++ b/Sources/AppShell/StatusMenuView.swift
@@ -215,7 +215,7 @@ private struct PopoverMenuRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(isHovered ? .white : .black)
+        .foregroundStyle(isHovered ? .white : .primary)
         .background(isHovered ? Color.accentColor : .clear)
         .clipShape(MenuRowShape(topRadius: 4, bottomRadius: isLast ? 12 : 4))
         .onHover { isHovered = $0 }


### PR DESCRIPTION
## Summary

- **Menu bar icon**: Set `isTemplate = true` on the status bar `NSImage` so macOS automatically renders the icon in the correct color for light/dark menu bar
- **Popover text**: Changed `PopoverMenuRow` foreground from hardcoded `.black` to `.primary`, fixing unreadable text in dark mode
- **Status bar updates**: Optimized `updateStatusBarButton` to only update changed properties (image, title, layout mode), reducing unnecessary AppKit layout recalculations

## Test plan

- [ ] Verify menu bar icon is visible in both light and dark mode
- [ ] Open the popover and confirm all menu items are readable in dark mode
- [ ] Confirm the update badge dot still appears when an update is available