### PR TITLE
Destroy Break Overlay Window After Dismissal + Lazy NSPopover creation

### DIFF
--- a/Sources/AppShell/ApplicationDelegate.swift
+++ b/Sources/AppShell/ApplicationDelegate.swift
@@ -8,7 +8,7 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
     private let updateManager: any UpdateManaging
     private var statusItem: NSStatusItem!
-    private var popover: NSPopover!
+    private var popover: NSPopover?
     private var cancellables = Set<AnyCancellable>()
     private var eventMonitor: Any?
     private var lastCloseDate: Date = .distantPast
@@ -40,17 +40,6 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
             button.sendAction(on: [.leftMouseUp])
         }
 
-        let pop = NSPopover()
-        pop.behavior = .applicationDefined
-        pop.animates = false
-        pop.contentViewController = NSHostingController(
-            rootView: PopoverContentView(
-                model: model,
-                dismiss: { [weak self] in self?.closePopover() }
-            )
-        )
-        popover = pop
-
         model.$appState
             .combineLatest(model.$launchPhase, model.$updateState)
             .sink { [weak self] appState, launchPhase, updateState in
@@ -71,14 +60,31 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
         if Date().timeIntervalSince(lastCloseDate) < 0.25 { return }
 
-        if popover.isShown {
+        if popover?.isShown ?? false {
             closePopover()
         } else {
             openPopover(relativeTo: button)
         }
     }
 
+    private func makePopover() -> NSPopover {
+        let pop = NSPopover()
+        pop.behavior = .applicationDefined
+        pop.animates = false
+        pop.contentViewController = NSHostingController(
+            rootView: PopoverContentView(
+                model: model,
+                dismiss: { [weak self] in self?.closePopover() }
+            )
+        )
+        return pop
+    }
+
     private func openPopover(relativeTo button: NSStatusBarButton) {
+        if popover == nil {
+            popover = makePopover()
+        }
+        guard let popover else { return }
         NSApp.activate(ignoringOtherApps: true)
         let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         popover.contentViewController?.view.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
@@ -88,10 +94,11 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func closePopover() {
-        guard popover.isShown else { return }
+        guard let popover, popover.isShown else { return }
         popover.performClose(nil)
         lastCloseDate = Date()
         removeEventMonitor()
+        self.popover = nil
     }
 
     private func installEventMonitor() {

--- a/Sources/AppShell/BreakOverlayWindowController.swift
+++ b/Sources/AppShell/BreakOverlayWindowController.swift
@@ -31,7 +31,11 @@ final class BreakOverlayWindowController {
     func hide() {
         guard let window else { return }
         isDismissing = true
-        OverlayWindowHelper.dismissOverlay(window)
+        OverlayWindowHelper.dismissOverlay(window) { [weak self] in
+            if self?.window === window {
+                self?.window = nil
+            }
+        }
     }
 
     var isVisible: Bool {

--- a/Sources/AppShell/OverlayWindowHelper.swift
+++ b/Sources/AppShell/OverlayWindowHelper.swift
@@ -36,6 +36,8 @@ enum OverlayWindowHelper {
             window.animator().alphaValue = 0
         }
         window.alphaValue = 0
+        // Stop all Core Animation animations so they don't continue running on a window that is about to be reused or torn down.
+        window.contentView?.layer?.removeAllAnimations()
     }
 
     static func presentOverlay<Content: View>(
@@ -74,7 +76,11 @@ enum OverlayWindowHelper {
         }
     }
 
-    static func dismissOverlay(_ window: NSWindow, fadeDuration: TimeInterval = 0.4) {
+    static func dismissOverlay(
+        _ window: NSWindow,
+        fadeDuration: TimeInterval = 0.4,
+        completion: @escaping @MainActor () -> Void = {}
+    ) {
         let generation = dismissGeneration
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = fadeDuration
@@ -84,6 +90,7 @@ enum OverlayWindowHelper {
             Task { @MainActor in
                 guard generation == dismissGeneration else { return }
                 window.orderOut(nil)
+                completion()
             }
         })
     }


### PR DESCRIPTION
- Addresses part of #26 
- Feel free to modify code. Changes made by AI but I reviewed them all.


## Destroy Break Overlay Window After Dismissal

🤖:

> ### Problem
> 
> `BreakOverlayWindowController.hide()` called `OverlayWindowHelper.dismissOverlay()` which only performed `window.orderOut(nil)` — the `NSWindow` was **never destroyed**. The window, its `NSHostingView`, and the `FloatingOrb` CALayers with `.repeatForever` blur+offset animations persisted indefinitely on the hidden window, consuming CPU after every break overlay dismissed.
> 
> ### Changes (2 files, +20/-2 lines)
> 
> **`Sources/AppShell/OverlayWindowHelper.swift`**:
> 
> 1. **`cancelAnimations`**: Added `window.contentView?.layer?.removeAllAnimations()` — stops stale `FloatingOrb` `.repeatForever` CAAnimations immediately when a window is being recycled for a new overlay
> 2. **`dismissOverlay`**: Added `completion: @escaping @MainActor () -> Void = {}` parameter — allows callers to perform post-dismiss cleanup. Default `{}` preserves backward compatibility with `OnboardingFlowWindowController`
> 
> **`Sources/AppShell/BreakOverlayWindowController.swift`**:
> 
> 3. **`hide()`**: Passes a completion handler to `dismissOverlay` that nils `self.window` after the fade-out completes, guarded by `self?.window === window` identity check — this prevents the window from being prematurely deallocated if `show()` reuses it concurrently
> 
> ### Safety
> 
> - The existing `dismissGeneration` guard in `dismissOverlay` (line 93) prevents the completion from firing if a new overlay was shown (`presentOverlay` increments `dismissGeneration`)
> - The `self?.window === window` identity check is an additional safety net: if `show()` reuses the window before `hide()`'s completion fires, the reference count won't be incorrectly nilled
> - `OnboardingFlowWindowController.hide()` is unaffected (uses default `{}` completion)
> - The window is recreated fresh on next `show()` via `self.window ?? OverlayWindowHelper.makeFullscreenWindow()`
> 
> ### Impact
> 
> - **Before**: `.repeatForever` blur animations on `FloatingOrb` layers continued running on hidden-but-retained windows at 60-120 Hz indefinitely after overlay dismissal
> - **After**: Window is fully deallocated after the 0.4s fade-out → ARC releases `NSHostingView` → CALayer tree deallocates → all CAAnimations immediately stop

## Lazy NSPopover creation

🤖:

>  The `NSPopover` + `StatusMenuView` SwiftUI tree is now created lazily on first `openPopover` and destroyed (`popover = nil`) on `closePopover`. This stops the 1Hz `objectWillChange` re-renders from hitting the hidden `StatusMenuView` with its expensive `MenuRowShape` path calculations.