### PR TITLE
Implements #23 (manual break overlay dismissal) and #22 (end-of-break sound).

### DIFF
--- a/Sources/AppShell/AppModel.swift
+++ b/Sources/AppShell/AppModel.swift
@@ -330,6 +330,10 @@ final class AppModel: ObservableObject {
             scheduleNotification(title: breakSession.kind.title, body: breakSession.message)
         }
 
+        if snapshot.breakJustReachedEnd {
+            playSound(for: settings.breakSettings.selectedEndSound)
+        }
+
         if snapshot.breakJustEnded, let kind = snapshot.completedBreakKind {
             breakStats = breakStatsStore.recordBreak(kind: kind, on: now)
         }

--- a/Sources/AppShell/AppModel.swift
+++ b/Sources/AppShell/AppModel.swift
@@ -247,6 +247,13 @@ final class AppModel: ObservableObject {
         apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
     }
 
+    func dismissBreak() {
+        guard launchPhase == .ready else { return }
+        let now = Date()
+        let snapshot = scheduler.dismissBreak(at: now)
+        apply(snapshot: snapshot, now: now, idleSeconds: activityMonitor.idleSeconds)
+    }
+
     func saveSettings() {
         do {
             try settingsStore.save(settings)

--- a/Sources/AppShell/ApplicationDelegate.swift
+++ b/Sources/AppShell/ApplicationDelegate.swift
@@ -8,7 +8,7 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
     private let updateManager: any UpdateManaging
     private var statusItem: NSStatusItem!
-    private var popover: NSPopover!
+    private var popover: NSPopover?
     private var cancellables = Set<AnyCancellable>()
     private var eventMonitor: Any?
     private var lastCloseDate: Date = .distantPast
@@ -40,17 +40,6 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
             button.sendAction(on: [.leftMouseUp])
         }
 
-        let pop = NSPopover()
-        pop.behavior = .applicationDefined
-        pop.animates = false
-        pop.contentViewController = NSHostingController(
-            rootView: PopoverContentView(
-                model: model,
-                dismiss: { [weak self] in self?.closePopover() }
-            )
-        )
-        popover = pop
-
         model.$appState
             .combineLatest(model.$launchPhase, model.$updateState)
             .sink { [weak self] appState, launchPhase, updateState in
@@ -71,14 +60,31 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
 
         if Date().timeIntervalSince(lastCloseDate) < 0.25 { return }
 
-        if popover.isShown {
+        if popover?.isShown ?? false {
             closePopover()
         } else {
             openPopover(relativeTo: button)
         }
     }
 
+    private func makePopover() -> NSPopover {
+        let pop = NSPopover()
+        pop.behavior = .applicationDefined
+        pop.animates = false
+        pop.contentViewController = NSHostingController(
+            rootView: PopoverContentView(
+                model: model,
+                dismiss: { [weak self] in self?.closePopover() }
+            )
+        )
+        return pop
+    }
+
     private func openPopover(relativeTo button: NSStatusBarButton) {
+        if popover == nil {
+            popover = makePopover()
+        }
+        guard let popover else { return }
         NSApp.activate(ignoringOtherApps: true)
         let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         popover.contentViewController?.view.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
@@ -88,10 +94,11 @@ final class ApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func closePopover() {
-        guard popover.isShown else { return }
+        guard let popover, popover.isShown else { return }
         popover.performClose(nil)
         lastCloseDate = Date()
         removeEventMonitor()
+        self.popover = nil
     }
 
     private func installEventMonitor() {

--- a/Sources/AppShell/BreakOverlayView.swift
+++ b/Sources/AppShell/BreakOverlayView.swift
@@ -10,6 +10,10 @@ struct BreakOverlayView: View {
         model.appState.countdownText ?? "00:00"
     }
 
+    private var isOver: Bool {
+        model.appState.breakNeedsDismissal && model.appState.activeBreak?.id == session.id
+    }
+
     var body: some View {
         ZStack {
             BreakBackgroundView(style: session.backgroundStyle)
@@ -26,23 +30,30 @@ struct BreakOverlayView: View {
                     .foregroundStyle(.white)
                     .frame(maxWidth: 600)
 
-                Text("Break ends in \(remainingText)")
+                Text(isOver ? "Break is over" : "Break ends in \(remainingText)")
                     .font(.system(size: 17, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(.white.opacity(0.6))
 
                 HStack(spacing: 14) {
-                    if model.settings.breakSettings.allowEarlyEnd {
-                        Button("End Early") {
-                            model.endBreakEarly()
+                    if isOver {
+                        Button("Dismiss") {
+                            model.dismissBreak()
                         }
                         .buttonStyle(OverlayButtonStyle(filled: true))
-                    }
+                    } else {
+                        if model.settings.breakSettings.allowEarlyEnd {
+                            Button("End Early") {
+                                model.endBreakEarly()
+                            }
+                            .buttonStyle(OverlayButtonStyle(filled: true))
+                        }
 
-                    Button("Skip") {
-                        model.skipCurrentBreak()
+                        Button("Skip") {
+                            model.skipCurrentBreak()
+                        }
+                        .buttonStyle(OverlayButtonStyle(filled: false))
                     }
-                    .buttonStyle(OverlayButtonStyle(filled: false))
                 }
                 .padding(.top, 8)
             }

--- a/Sources/AppShell/BreakOverlayWindowController.swift
+++ b/Sources/AppShell/BreakOverlayWindowController.swift
@@ -31,7 +31,11 @@ final class BreakOverlayWindowController {
     func hide() {
         guard let window else { return }
         isDismissing = true
-        OverlayWindowHelper.dismissOverlay(window)
+        OverlayWindowHelper.dismissOverlay(window) { [weak self] in
+            if self?.window === window {
+                self?.window = nil
+            }
+        }
     }
 
     var isVisible: Bool {

--- a/Sources/AppShell/OverlayWindowHelper.swift
+++ b/Sources/AppShell/OverlayWindowHelper.swift
@@ -36,6 +36,8 @@ enum OverlayWindowHelper {
             window.animator().alphaValue = 0
         }
         window.alphaValue = 0
+        // Stop all Core Animation animations so they don't continue running on a window that is about to be reused or torn down.
+        window.contentView?.layer?.removeAllAnimations()
     }
 
     static func presentOverlay<Content: View>(
@@ -74,7 +76,11 @@ enum OverlayWindowHelper {
         }
     }
 
-    static func dismissOverlay(_ window: NSWindow, fadeDuration: TimeInterval = 0.4) {
+    static func dismissOverlay(
+        _ window: NSWindow,
+        fadeDuration: TimeInterval = 0.4,
+        completion: @escaping @MainActor () -> Void = {}
+    ) {
         let generation = dismissGeneration
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = fadeDuration
@@ -84,6 +90,7 @@ enum OverlayWindowHelper {
             Task { @MainActor in
                 guard generation == dismissGeneration else { return }
                 window.orderOut(nil)
+                completion()
             }
         })
     }

--- a/Sources/AppShell/SettingsView.swift
+++ b/Sources/AppShell/SettingsView.swift
@@ -357,8 +357,21 @@ private struct AppearanceSettingsPane: View {
                         Text(sound.rawValue.capitalized).tag(sound)
                     }
                 }
+
+                Picker("End of break sound", selection: Binding(
+                    get: { model.settings.breakSettings.selectedEndSound },
+                    set: { newValue in
+                        model.settings.breakSettings.selectedEndSound = newValue
+                        model.saveSettings()
+                        Self.previewSound(newValue)
+                    }
+                )) {
+                    ForEach(BreakSound.allCases) { sound in
+                        Text(sound.rawValue.capitalized).tag(sound)
+                    }
+                }
             } footer: {
-                Text("Sound played when a break starts.")
+                Text("Sound played when a break starts, and when a break ends.")
             }
 
             Section {

--- a/Sources/AppShell/SettingsView.swift
+++ b/Sources/AppShell/SettingsView.swift
@@ -280,6 +280,18 @@ private struct BreaksSettingsPane: View {
             }
 
             Section {
+                Toggle("Keep overlay open until dismissed", isOn: Binding(
+                    get: { model.settings.breakSettings.manualBreakDismissal },
+                    set: { newValue in
+                        model.settings.breakSettings.manualBreakDismissal = newValue
+                        model.saveSettings()
+                    }
+                ))
+            } footer: {
+                Text("When enabled, the break overlay stays on screen after the break ends until you click Dismiss. The next work interval won't start until then.")
+            }
+
+            Section {
                 Toggle("Long breaks", isOn: Binding(
                     get: { model.settings.breakSettings.longBreaksEnabled },
                     set: { newValue in

--- a/Sources/Core/BreakScheduler.swift
+++ b/Sources/Core/BreakScheduler.swift
@@ -113,6 +113,10 @@ public final class BreakScheduler: @unchecked Sendable {
 
         if let breakSession = activeBreak {
             if now >= breakSession.scheduledEnd {
+                if settings.breakSettings.manualBreakDismissal {
+                    statusText = "Break complete \u{2014} dismiss to continue"
+                    return snapshot(now: now, breakJustStarted: false, breakJustEnded: false)
+                }
                 let kind = breakSession.kind
                 completeActiveBreak(at: now)
                 return snapshot(now: now, breakJustStarted: false, breakJustEnded: true, completedBreakKind: kind)
@@ -191,6 +195,17 @@ public final class BreakScheduler: @unchecked Sendable {
         let kind = breakSession.kind
         completeActiveBreak(at: now)
         statusText = "Break ended early"
+        return snapshot(now: now, breakJustStarted: false, breakJustEnded: true, completedBreakKind: kind)
+    }
+
+    public func dismissBreak(at now: Date) -> Snapshot {
+        guard let breakSession = activeBreak else {
+            return snapshot(now: now, breakJustStarted: false, breakJustEnded: false)
+        }
+
+        let kind = breakSession.kind
+        completeActiveBreak(at: now)
+        statusText = "Break dismissed"
         return snapshot(now: now, breakJustStarted: false, breakJustEnded: true, completedBreakKind: kind)
     }
 
@@ -304,7 +319,8 @@ public final class BreakScheduler: @unchecked Sendable {
                 activeBreak: activeBreak,
                 isPaused: isPaused,
                 pauseReason: pauseReason,
-                statusText: statusText
+                statusText: statusText,
+                breakNeedsDismissal: settings.breakSettings.manualBreakDismissal && activeBreak.map { now >= $0.scheduledEnd } == true
             ),
             breakJustStarted: breakJustStarted,
             breakJustEnded: breakJustEnded,

--- a/Sources/Core/BreakScheduler.swift
+++ b/Sources/Core/BreakScheduler.swift
@@ -10,12 +10,20 @@ public final class BreakScheduler: @unchecked Sendable {
         public var state: AppState
         public var breakJustStarted: Bool
         public var breakJustEnded: Bool
+        public var breakJustReachedEnd: Bool
         public var completedBreakKind: BreakKind?
 
-        public init(state: AppState, breakJustStarted: Bool, breakJustEnded: Bool, completedBreakKind: BreakKind? = nil) {
+        public init(
+            state: AppState,
+            breakJustStarted: Bool,
+            breakJustEnded: Bool,
+            completedBreakKind: BreakKind? = nil,
+            breakJustReachedEnd: Bool = false
+        ) {
             self.state = state
             self.breakJustStarted = breakJustStarted
             self.breakJustEnded = breakJustEnded
+            self.breakJustReachedEnd = breakJustReachedEnd
             self.completedBreakKind = completedBreakKind
         }
     }
@@ -41,6 +49,7 @@ public final class BreakScheduler: @unchecked Sendable {
     private var manualPauseRemainingUntilBreak: TimeInterval?
     private var statusText = "Preparing your first session"
     private let smartPauseResumeGracePeriod: TimeInterval = 2 * 60
+    private var hasAnnouncedBreakEnd = false
 
     public init(
         settings: AppSettings = .default,
@@ -113,13 +122,17 @@ public final class BreakScheduler: @unchecked Sendable {
 
         if let breakSession = activeBreak {
             if now >= breakSession.scheduledEnd {
+                let reachedEnd = !hasAnnouncedBreakEnd
+                if reachedEnd {
+                    hasAnnouncedBreakEnd = true
+                }
                 if settings.breakSettings.manualBreakDismissal {
                     statusText = "Break complete \u{2014} dismiss to continue"
-                    return snapshot(now: now, breakJustStarted: false, breakJustEnded: false)
+                    return snapshot(now: now, breakJustStarted: false, breakJustEnded: false, breakJustReachedEnd: reachedEnd)
                 }
                 let kind = breakSession.kind
                 completeActiveBreak(at: now)
-                return snapshot(now: now, breakJustStarted: false, breakJustEnded: true, completedBreakKind: kind)
+                return snapshot(now: now, breakJustStarted: false, breakJustEnded: true, breakJustReachedEnd: reachedEnd, completedBreakKind: kind)
             }
 
             let remaining = breakSession.scheduledEnd.timeIntervalSince(now)
@@ -274,6 +287,7 @@ public final class BreakScheduler: @unchecked Sendable {
         )
         postponedUntil = nil
         nextBreakDate = nil
+        hasAnnouncedBreakEnd = false
         statusText = "\(kind.title) started"
     }
 
@@ -306,6 +320,7 @@ public final class BreakScheduler: @unchecked Sendable {
         now: Date,
         breakJustStarted: Bool,
         breakJustEnded: Bool,
+        breakJustReachedEnd: Bool = false,
         completedBreakKind: BreakKind? = nil
     ) -> Snapshot {
         let displayedNextBreakDate = automaticPauseState?.remainingUntilBreak.map {
@@ -324,7 +339,8 @@ public final class BreakScheduler: @unchecked Sendable {
             ),
             breakJustStarted: breakJustStarted,
             breakJustEnded: breakJustEnded,
-            completedBreakKind: completedBreakKind
+            completedBreakKind: completedBreakKind,
+            breakJustReachedEnd: breakJustReachedEnd
         )
     }
 

--- a/Sources/Core/Models.swift
+++ b/Sources/Core/Models.swift
@@ -83,6 +83,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
     public var skipPolicy: SkipPolicy
     public var customMessages: [String]
     public var selectedSound: BreakSound
+    public var selectedEndSound: BreakSound
     public var backgroundStyle: BreakBackgroundStyle
     public var manualBreakDismissal: Bool
 
@@ -96,6 +97,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         skipPolicy: SkipPolicy,
         customMessages: [String],
         selectedSound: BreakSound,
+        selectedEndSound: BreakSound = .none,
         backgroundStyle: BreakBackgroundStyle,
         manualBreakDismissal: Bool = false
     ) {
@@ -108,6 +110,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         self.skipPolicy = skipPolicy
         self.customMessages = customMessages
         self.selectedSound = selectedSound
+        self.selectedEndSound = selectedEndSound
         self.backgroundStyle = backgroundStyle
         self.manualBreakDismissal = manualBreakDismissal
     }
@@ -139,6 +142,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         case skipPolicy
         case customMessages
         case selectedSound
+        case selectedEndSound
         case backgroundStyle
         case manualBreakDismissal
     }
@@ -154,6 +158,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         self.skipPolicy = try container.decode(SkipPolicy.self, forKey: .skipPolicy)
         self.customMessages = try container.decode([String].self, forKey: .customMessages)
         self.selectedSound = try container.decode(BreakSound.self, forKey: .selectedSound)
+        self.selectedEndSound = try container.decodeIfPresent(BreakSound.self, forKey: .selectedEndSound) ?? .none
         self.backgroundStyle = try container.decode(BreakBackgroundStyle.self, forKey: .backgroundStyle)
         self.manualBreakDismissal = try container.decodeIfPresent(Bool.self, forKey: .manualBreakDismissal) ?? false
     }

--- a/Sources/Core/Models.swift
+++ b/Sources/Core/Models.swift
@@ -84,6 +84,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
     public var customMessages: [String]
     public var selectedSound: BreakSound
     public var backgroundStyle: BreakBackgroundStyle
+    public var manualBreakDismissal: Bool
 
     public init(
         workInterval: TimeInterval,
@@ -95,7 +96,8 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         skipPolicy: SkipPolicy,
         customMessages: [String],
         selectedSound: BreakSound,
-        backgroundStyle: BreakBackgroundStyle
+        backgroundStyle: BreakBackgroundStyle,
+        manualBreakDismissal: Bool = false
     ) {
         self.workInterval = workInterval
         self.microBreakDuration = microBreakDuration
@@ -107,6 +109,7 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         self.customMessages = customMessages
         self.selectedSound = selectedSound
         self.backgroundStyle = backgroundStyle
+        self.manualBreakDismissal = manualBreakDismissal
     }
 
     public static let `default` = BreakSettings(
@@ -125,6 +128,35 @@ public struct BreakSettings: Codable, Hashable, Sendable {
         selectedSound: .breeze,
         backgroundStyle: .dawn
     )
+
+    private enum CodingKeys: String, CodingKey {
+        case workInterval
+        case microBreakDuration
+        case longBreakDuration
+        case longBreakCadence
+        case longBreaksEnabled
+        case allowEarlyEnd
+        case skipPolicy
+        case customMessages
+        case selectedSound
+        case backgroundStyle
+        case manualBreakDismissal
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.workInterval = try container.decode(TimeInterval.self, forKey: .workInterval)
+        self.microBreakDuration = try container.decode(TimeInterval.self, forKey: .microBreakDuration)
+        self.longBreakDuration = try container.decode(TimeInterval.self, forKey: .longBreakDuration)
+        self.longBreakCadence = try container.decode(Int.self, forKey: .longBreakCadence)
+        self.longBreaksEnabled = try container.decode(Bool.self, forKey: .longBreaksEnabled)
+        self.allowEarlyEnd = try container.decode(Bool.self, forKey: .allowEarlyEnd)
+        self.skipPolicy = try container.decode(SkipPolicy.self, forKey: .skipPolicy)
+        self.customMessages = try container.decode([String].self, forKey: .customMessages)
+        self.selectedSound = try container.decode(BreakSound.self, forKey: .selectedSound)
+        self.backgroundStyle = try container.decode(BreakBackgroundStyle.self, forKey: .backgroundStyle)
+        self.manualBreakDismissal = try container.decodeIfPresent(Bool.self, forKey: .manualBreakDismissal) ?? false
+    }
 }
 
 public struct ScheduleSettings: Codable, Hashable, Sendable {
@@ -590,6 +622,7 @@ public struct AppState: Sendable {
     public var isPaused: Bool
     public var pauseReason: String?
     public var statusText: String
+    public var breakNeedsDismissal: Bool
 
     public init(
         now: Date,
@@ -597,7 +630,8 @@ public struct AppState: Sendable {
         activeBreak: BreakSession?,
         isPaused: Bool,
         pauseReason: String?,
-        statusText: String
+        statusText: String,
+        breakNeedsDismissal: Bool = false
     ) {
         self.now = now
         self.nextBreakDate = nextBreakDate
@@ -605,6 +639,7 @@ public struct AppState: Sendable {
         self.isPaused = isPaused
         self.pauseReason = pauseReason
         self.statusText = statusText
+        self.breakNeedsDismissal = breakNeedsDismissal
     }
 }
 

--- a/Tests/CoreTests/BreakSchedulerTests.swift
+++ b/Tests/CoreTests/BreakSchedulerTests.swift
@@ -148,6 +148,81 @@ final class BreakSchedulerTests: XCTestCase {
         XCTAssertEqual(afterEnd.state.nextBreakDate, start.addingTimeInterval(130))
     }
 
+    func testBreakJustReachedEndFiresOnceWhenBreakCompletesAutomatically() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = false
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        let afterEnd = scheduler.advance(to: start.addingTimeInterval(70), idleSeconds: 0)
+        let nextTick = scheduler.advance(to: start.addingTimeInterval(80), idleSeconds: 0)
+
+        XCTAssertTrue(afterEnd.breakJustReachedEnd)
+        XCTAssertFalse(nextTick.breakJustReachedEnd)
+    }
+
+    func testBreakJustReachedEndFiresOnceWhileHeldForManualDismissal() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = true
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        let reachedEnd = scheduler.advance(to: start.addingTimeInterval(70), idleSeconds: 0)
+        let stillHeld = scheduler.advance(to: start.addingTimeInterval(80), idleSeconds: 0)
+        let dismissed = scheduler.dismissBreak(at: start.addingTimeInterval(90))
+
+        XCTAssertTrue(reachedEnd.breakJustReachedEnd)
+        XCTAssertFalse(reachedEnd.breakJustEnded)
+        XCTAssertNotNil(reachedEnd.state.activeBreak)
+        XCTAssertFalse(stillHeld.breakJustReachedEnd)
+        XCTAssertTrue(stillHeld.state.breakNeedsDismissal)
+        XCTAssertTrue(dismissed.breakJustEnded)
+        XCTAssertFalse(dismissed.breakJustReachedEnd)
+    }
+
+    func testEndBreakEarlyDoesNotEmitReachedEndSignal() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = true
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        let endedEarly = scheduler.endBreakEarly(at: start.addingTimeInterval(65))
+
+        XCTAssertTrue(endedEarly.breakJustEnded)
+        XCTAssertFalse(endedEarly.breakJustReachedEnd)
+    }
+
+    func testBreakJustReachedEndResetsForNextBreak() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = true
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(70), idleSeconds: 0)
+        _ = scheduler.dismissBreak(at: start.addingTimeInterval(80))
+
+        _ = scheduler.advance(to: start.addingTimeInterval(140), idleSeconds: 0)
+        let secondBreakEnded = scheduler.advance(to: start.addingTimeInterval(150), idleSeconds: 0)
+
+        XCTAssertTrue(secondBreakEnded.breakJustReachedEnd)
+    }
+
     @MainActor
     func testSmartPauseSuppressesBreakWhileProviderIsActive() {
         var settings = AppSettings.default

--- a/Tests/CoreTests/BreakSchedulerTests.swift
+++ b/Tests/CoreTests/BreakSchedulerTests.swift
@@ -104,6 +104,50 @@ final class BreakSchedulerTests: XCTestCase {
         XCTAssertEqual(snapshot.state.statusText, "Outside office hours")
     }
 
+    func testManualDismissalHoldsBreakOverlayAfterBreakEnds() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = true
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        let started = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        XCTAssertTrue(started.breakJustStarted)
+
+        let afterEnd = scheduler.advance(to: start.addingTimeInterval(70), idleSeconds: 0)
+        XCTAssertFalse(afterEnd.breakJustEnded)
+        XCTAssertNotNil(afterEnd.state.activeBreak)
+        XCTAssertTrue(afterEnd.state.breakNeedsDismissal)
+        XCTAssertNil(afterEnd.state.nextBreakDate)
+
+        let dismissed = scheduler.dismissBreak(at: start.addingTimeInterval(80))
+        XCTAssertTrue(dismissed.breakJustEnded)
+        XCTAssertEqual(dismissed.completedBreakKind, .micro)
+        XCTAssertNil(dismissed.state.activeBreak)
+        XCTAssertFalse(dismissed.state.breakNeedsDismissal)
+        XCTAssertEqual(dismissed.state.nextBreakDate, start.addingTimeInterval(140))
+    }
+
+    func testManualDismissalDisabledStillEndsBreakAutomatically() {
+        var settings = AppSettings.default
+        settings.breakSettings.workInterval = 60
+        settings.breakSettings.microBreakDuration = 10
+        settings.breakSettings.manualBreakDismissal = false
+        let scheduler = BreakScheduler(settings: settings)
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+        _ = scheduler.advance(to: start, idleSeconds: 0)
+        _ = scheduler.advance(to: start.addingTimeInterval(60), idleSeconds: 0)
+        let afterEnd = scheduler.advance(to: start.addingTimeInterval(70), idleSeconds: 0)
+
+        XCTAssertTrue(afterEnd.breakJustEnded)
+        XCTAssertNil(afterEnd.state.activeBreak)
+        XCTAssertFalse(afterEnd.state.breakNeedsDismissal)
+        XCTAssertEqual(afterEnd.state.nextBreakDate, start.addingTimeInterval(130))
+    }
+
     @MainActor
     func testSmartPauseSuppressesBreakWhileProviderIsActive() {
         var settings = AppSettings.default

--- a/Tests/CoreTests/SettingsStoreTests.swift
+++ b/Tests/CoreTests/SettingsStoreTests.swift
@@ -88,6 +88,7 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(loaded.schemaVersion, AppSettings.currentSchemaVersion)
         XCTAssertFalse(loaded.smartPauseSettings.pauseDuringFullscreenFocus)
         XCTAssertFalse(loaded.breakSettings.manualBreakDismissal)
+        XCTAssertEqual(loaded.breakSettings.selectedEndSound, .none)
         XCTAssertFalse(persistedAfterMigration.contains("reminderLeadTime"))
     }
 

--- a/Tests/CoreTests/SettingsStoreTests.swift
+++ b/Tests/CoreTests/SettingsStoreTests.swift
@@ -87,6 +87,7 @@ final class SettingsStoreTests: XCTestCase {
 
         XCTAssertEqual(loaded.schemaVersion, AppSettings.currentSchemaVersion)
         XCTAssertFalse(loaded.smartPauseSettings.pauseDuringFullscreenFocus)
+        XCTAssertFalse(loaded.breakSettings.manualBreakDismissal)
         XCTAssertFalse(persistedAfterMigration.contains("reminderLeadTime"))
     }
 


### PR DESCRIPTION
- Implements #23 (manual break overlay dismissal) and #22 (end-of-break sound). 
- All changes made by AI, reviewed manually.

**Please merge #27 first.**

This branch was created on top of #27, so GitHub currently shows 4 commits here — the first 2 belong to #27. Once #27 is merged, this PR's diff automatically shrinks to just its 2 new commits.

## New settings

- `BreakSettings.manualBreakDismissal` (default `false`)
- `BreakSettings.selectedEndSound` (default `.none`)

**Backward compatibility — custom `init(from:)` decoder**

`BreakSettings` now declares a `CodingKeys` enum and a custom `init(from:)` (same pattern `SmartPauseSettings` already uses). All existing keys decode as before, and the two new fields use `decodeIfPresent` with defaults, so old `settings.json` files load unchanged:
- `selectedEndSound` → `decodeIfPresent(BreakSound.self, ...) ?? .none`
- `manualBreakDismissal` → `decodeIfPresent(Bool.self, ...) ?? false`

`AppSettings.currentSchemaVersion` stays at 5 — no migration needed, no data loss. Existing users get the new settings with their defaults until they opt in.
